### PR TITLE
#191 ユーザーの支持した投稿一覧を見るページ

### DIFF
--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -27,7 +27,7 @@ qa_register_plugin_phrases('qa-vote-page-lang-*.php', 'qa_vote_page');
 // process
 qa_register_plugin_module('process', 'qa-vote-page-process.php', 'qa_vote_page_process', 'Vote Page Process');
 // layer
-// qa_register_plugin_layer('qa-vote-page-layer.php','Vote Page Layer');
+qa_register_plugin_layer('qa-vote-page-layer.php','Vote Page Layer');
 
 /*
 	Omit PHP closing tag to help avoid accidental output

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+	Plugin Name: Vote Page
+	Plugin URI:
+	Plugin Description: Add page of questions and answers that the user has voted.
+	Plugin Version: 1.0
+	Plugin Date: 2016-08-03
+	Plugin Author: 38qa.net
+	Plugin Author URI: http://38qa.net/
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+// process
+// qa_register_plugin_module('process', 'qa-vote-page-process.php', 'qa_vote_page_process', 'Vote Page Process');
+// layer
+// qa_register_plugin_layer('qa-vote-page-layer.php','Vote Page Layer');
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -18,8 +18,12 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 	exit;
 }
 
+//Define global constants
+@define( 'VOTE_PAGE_DIR', dirname( __FILE__ ) );
+@define( 'VOTE_PAGE_FOLDER', basename( dirname( __FILE__ ) ) );
+
 // process
-// qa_register_plugin_module('process', 'qa-vote-page-process.php', 'qa_vote_page_process', 'Vote Page Process');
+qa_register_plugin_module('process', 'qa-vote-page-process.php', 'qa_vote_page_process', 'Vote Page Process');
 // layer
 // qa_register_plugin_layer('qa-vote-page-layer.php','Vote Page Layer');
 

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -22,6 +22,8 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 @define( 'VOTE_PAGE_DIR', dirname( __FILE__ ) );
 @define( 'VOTE_PAGE_FOLDER', basename( dirname( __FILE__ ) ) );
 
+// language file
+qa_register_plugin_phrases('qa-vote-page-lang-*.php', 'qa_vote_page');
 // process
 qa_register_plugin_module('process', 'qa-vote-page-process.php', 'qa_vote_page_process', 'Vote Page Process');
 // layer

--- a/qa-vote-page-lang-default.php
+++ b/qa-vote-page-lang-default.php
@@ -8,6 +8,7 @@
 		// default
 		'upvotes_by_x' => 'Upvotes by ^',
 		'no_upvotes_by_x' => 'No upvotes by ^',
+		'upvotes_posts' => 'Upvotes Posts',
 	);
 
 

--- a/qa-vote-page-lang-default.php
+++ b/qa-vote-page-lang-default.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+	Plugin Name: Vote Page
+*/
+
+	return array(
+		// default
+		'upvotes_by_x' => 'Upvotes by ^',
+		'no_upvotes_by_x' => 'No upvotes by ^',
+	);
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-vote-page-lang-ja.php
+++ b/qa-vote-page-lang-ja.php
@@ -8,6 +8,7 @@
 		// japanese
 		'upvotes_by_x' => '^ の支持した質問・回答',
 		'no_upvotes_by_x' => '^ の支持した質問や回答はありません',
+		'upvotes_posts' => 'すべての支持',
 	);
 
 

--- a/qa-vote-page-lang-ja.php
+++ b/qa-vote-page-lang-ja.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+	Plugin Name: Vote Page
+*/
+
+	return array(
+		// japanese
+		'upvotes_by_x' => '^ の支持した質問・回答',
+		'no_upvotes_by_x' => '^ の支持した質問や回答はありません',
+	);
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-vote-page-layer.php
+++ b/qa-vote-page-layer.php
@@ -1,0 +1,18 @@
+<?php
+
+if ( !defined( 'QA_VERSION' ) ) { // don't allow this page to be requested directly from browser
+	header( 'Location: ../' );
+	exit;
+}
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+	function body_content()
+	{
+		qa_html_theme_base::body_content();
+	}
+}
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-vote-page-layer.php
+++ b/qa-vote-page-layer.php
@@ -7,9 +7,41 @@ if ( !defined( 'QA_VERSION' ) ) { // don't allow this page to be requested direc
 
 class qa_html_theme_layer extends qa_html_theme_base
 {
-	function body_content()
+	public function head()
 	{
-		qa_html_theme_base::body_content();
+		$this->add_user_upvotes_sub_nav();
+		qa_html_theme_base::head();
+	}
+
+	private function add_user_upvotes_sub_nav()
+	{
+		$content = &$this->content;
+
+		if ( isset( $content['navigation']['sub']['profile'] ) ) {
+			//means the control is on the profile page , so display here the user blogs menu
+			$sub_nav = &$content['navigation']['sub'];
+			$handle = qa_request_part(1);
+			$this->user_sub_navigation( $sub_nav, $handle ? $handle : qa_get_logged_in_handle() );
+		}
+
+	}
+
+	private function user_sub_navigation(&$sub_nav, $handle)
+	{
+		$nav = array(
+			'upvotes' => array(
+				'label'	=> qa_lang_html('qa_vote_page/upvotes_posts'),
+				'url'	  => qa_path_html('user/'.$handle.'/upvotes'),
+				'selected' => qa_request_part(2) === 'upvotes' ? true : false,
+			)
+		);
+
+		if (isset($sub_nav['user_blogs'])) {
+			qa_array_insert($sub_nav, 'user_blogs', $nav);
+		} else {
+			$sub_nav[] = $nav;
+		}
+
 	}
 }
 

--- a/qa-vote-page-process.php
+++ b/qa-vote-page-process.php
@@ -9,7 +9,9 @@ class qa_vote_page_process
 {
 	public function init_page()
 	{
-		if (qa_request_part(0) !== 'user' || empty(qa_request_part(2)) || qa_request_part(2) !== 'upvotes') {
+		$page = qa_request_part(0);
+		$action = qa_request_part(2);
+		if ($page !== 'user' || empty($action) || $action !== 'upvotes') {
 			return;
 		}
 

--- a/qa-vote-page-process.php
+++ b/qa-vote-page-process.php
@@ -56,7 +56,7 @@ class qa_vote_page_process
 		}
 
 		qa_set_template('user-upvotes');
-		$qa_content = include VOTE_PAGE_DIR.'user-upvotes.php';
+		$qa_content = include VOTE_PAGE_DIR.'/user-upvotes.php';
 
 		if (is_array($qa_content)) {
 			if (QA_DEBUG_PERFORMANCE)

--- a/qa-vote-page-process.php
+++ b/qa-vote-page-process.php
@@ -1,0 +1,79 @@
+<?php
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+class qa_vote_page_process
+{
+	public function init_page()
+	{
+		if (qa_request_part(0) !== 'user' || empty(qa_request_part(2)) || qa_request_part(2) !== 'upvotes') {
+			return;
+		}
+
+		require_once QA_INCLUDE_DIR.'app/cookies.php';
+		require_once QA_INCLUDE_DIR.'app/format.php';
+		require_once QA_INCLUDE_DIR.'app/users.php';
+		require_once QA_INCLUDE_DIR.'app/options.php';
+		require_once QA_INCLUDE_DIR.'db/selects.php';
+
+		global $qa_usage;
+
+		qa_report_process_stage('init_page');
+		qa_db_connect('qa_page_db_fail_handler');
+
+		qa_page_queue_pending();
+		qa_load_state();
+		qa_check_login_modules();
+
+		if (QA_DEBUG_PERFORMANCE)
+			$qa_usage->mark('setup');
+
+		qa_check_page_clicks();
+		//	Determine the identify of the user
+
+		$handle = qa_request_part(1);
+
+		if (!strlen($handle)) {
+			$handle = qa_get_logged_in_handle();
+			qa_redirect(!empty($handle) ? 'user/'.$handle : 'users');
+		}
+
+		//	Get the HTML to display for the handle, and if we're using external users, determine the userid
+
+		if (QA_FINAL_EXTERNAL_USERS) {
+			$userid = qa_handle_to_userid($handle);
+			if (!isset($userid))
+				return include QA_INCLUDE_DIR.'qa-page-not-found.php';
+
+			$usershtml = qa_get_users_html(array($userid), false, qa_path_to_root(), true);
+			$userhtml = @$usershtml[$userid];
+
+		} else {
+			$userhtml = qa_html($handle);
+		}
+
+		qa_set_template('user-upvotes');
+		$qa_content = include VOTE_PAGE_DIR.'user-upvotes.php';
+
+		if (is_array($qa_content)) {
+			if (QA_DEBUG_PERFORMANCE)
+				$qa_usage->mark('view');
+
+			qa_output_content($qa_content);
+
+			if (QA_DEBUG_PERFORMANCE)
+				$qa_usage->mark('theme');
+
+			if (qa_do_content_stats($qa_content) && QA_DEBUG_PERFORMANCE)
+				$qa_usage->mark('stats');
+
+			if (QA_DEBUG_PERFORMANCE)
+				$qa_usage->output();
+		}
+
+		qa_db_disconnect();
+	}
+}

--- a/user-upvotes.php
+++ b/user-upvotes.php
@@ -1,0 +1,116 @@
+<?php
+
+	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+		header('Location: ../');
+		exit;
+	}
+
+	require_once QA_INCLUDE_DIR.'db/selects.php';
+	require_once QA_INCLUDE_DIR.'app/format.php';
+
+
+//	$handle, $userhtml are already set by qa-page-user.php - also $userid if using external user integration
+
+
+//	Find the recent activity for this user
+
+	$loginuserid = qa_get_logged_in_userid();
+	$identifier = QA_FINAL_EXTERNAL_USERS ? $userid : $handle;
+
+	list($useraccount, $questions, $answerqs) = qa_db_select_with_pending(
+		QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_account_selectspec($handle, false),
+		qa_user_upvotes_qs_selectspec($loginuserid, $identifier, qa_opt_if_loaded('page_size_activity')),
+		qa_user_upvotes_a_qs_selectspec($loginuserid, $identifier)
+	);
+
+	if (!QA_FINAL_EXTERNAL_USERS && !is_array($useraccount)) // check the user exists
+		return include QA_INCLUDE_DIR.'qa-page-not-found.php';
+
+
+//	Get information on user references
+
+	$questions = qa_any_sort_and_dedupe(array_merge($questions, $answerqs));
+	$questions = array_slice($questions, 0, qa_opt('page_size_activity'));
+	$usershtml = qa_userids_handles_html(qa_any_get_userids_handles($questions), false);
+
+
+//	Prepare content for theme
+
+	$qa_content = qa_content_prepare(true);
+
+	if (count($questions))
+		$qa_content['title'] = qa_lang_html_sub('profile/recent_activity_by_x', $userhtml);
+	else
+		$qa_content['title'] = qa_lang_html_sub('profile/no_posts_by_x', $userhtml);
+
+
+//	Recent activity by this user
+
+	$qa_content['q_list']['form'] = array(
+		'tags' => 'method="post" action="'.qa_self_html().'"',
+
+		'hidden' => array(
+			'code' => qa_get_form_security_code('vote'),
+		),
+	);
+
+	$qa_content['q_list']['qs'] = array();
+
+	$htmldefaults = qa_post_html_defaults('Q');
+	$htmldefaults['whoview'] = false;
+	$htmldefaults['voteview'] = false;
+	$htmldefaults['avatarsize'] = 0;
+
+	foreach ($questions as $question) {
+		$qa_content['q_list']['qs'][] = qa_any_to_q_html_fields($question, $loginuserid, qa_cookie_get(),
+			$usershtml, null, array('voteview' => false) + qa_post_html_options($question, $htmldefaults));
+	}
+
+
+//	Sub menu for navigation in user pages
+
+	$ismyuser = isset($loginuserid) && $loginuserid == (QA_FINAL_EXTERNAL_USERS ? $userid : $useraccount['userid']);
+	$qa_content['navigation']['sub'] = qa_user_sub_navigation($handle, 'activity', $ismyuser);
+
+
+	return $qa_content;
+
+	function qa_user_upvotes_qs_selectspec($voteuserid, $identifier, $count=null, $start=0)
+	{
+		$count=isset($count) ? min($count, QA_DB_RETRIEVE_QS_AS) : QA_DB_RETRIEVE_QS_AS;
+
+		$selectspec=qa_db_posts_basic_selectspec($voteuserid);
+
+		$selectspec['source'].=" WHERE ^posts.postid IN (SELECT postid FROM ^uservotes WHERE userid=".(QA_FINAL_EXTERNAL_USERS ? "$" : "(SELECT userid FROM ^users WHERE handle=$ LIMIT 1)")." AND vote = 1) AND type='Q' ORDER BY ^posts.created DESC LIMIT #,#";
+		array_push($selectspec['arguments'], $identifier, $start, $count);
+		$selectspec['sortdesc']='created';
+
+		return $selectspec;
+	}
+
+	function qa_user_upvotes_a_qs_selectspec($voteuserid, $identifier, $count=null, $start=0)
+	{
+		$count=isset($count) ? min($count, QA_DB_RETRIEVE_QS_AS) : QA_DB_RETRIEVE_QS_AS;
+
+		$selectspec=qa_db_posts_basic_selectspec($voteuserid);
+
+		qa_db_add_selectspec_opost($selectspec, 'aposts');
+
+		$selectspec['columns']['oupvotes']='aposts.upvotes';
+		$selectspec['columns']['odownvotes']='aposts.downvotes';
+		$selectspec['columns']['onetvotes']='aposts.netvotes';
+
+		$selectspec['source'].=" JOIN ^posts AS aposts ON ^posts.postid=aposts.parentid".
+			" JOIN (SELECT postid FROM ^posts WHERE ".
+			" postid IN (SELECT postid FROM ^uservotes WHERE userid=".(QA_FINAL_EXTERNAL_USERS ? "$" : "(SELECT userid FROM ^users WHERE handle=$ LIMIT 1)"). " AND vote = 1)".
+			" AND type='A' ORDER BY created DESC LIMIT #,#) y ON aposts.postid=y.postid WHERE ^posts.type='Q'";
+
+		array_push($selectspec['arguments'], $identifier, $start, $count);
+		$selectspec['sortdesc']='otime';
+
+		return $selectspec;
+	}
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/user-upvotes.php
+++ b/user-upvotes.php
@@ -70,7 +70,7 @@
 //	Sub menu for navigation in user pages
 
 	$ismyuser = isset($loginuserid) && $loginuserid == (QA_FINAL_EXTERNAL_USERS ? $userid : $useraccount['userid']);
-	$qa_content['navigation']['sub'] = qa_user_sub_navigation($handle, 'activity', $ismyuser);
+	$qa_content['navigation']['sub'] = qa_user_sub_navigation($handle, 'upvotes', $ismyuser);
 
 
 	return $qa_content;

--- a/user-upvotes.php
+++ b/user-upvotes.php
@@ -39,9 +39,9 @@
 	$qa_content = qa_content_prepare(true);
 
 	if (count($questions))
-		$qa_content['title'] = qa_lang_html_sub('profile/recent_activity_by_x', $userhtml);
+		$qa_content['title'] = qa_lang_html_sub('qa_vote_page/upvotes_by_x', $userhtml);
 	else
-		$qa_content['title'] = qa_lang_html_sub('profile/no_posts_by_x', $userhtml);
+		$qa_content['title'] = qa_lang_html_sub('qa_vote_page/no_upvotes_by_x', $userhtml);
 
 
 //	Recent activity by this user


### PR DESCRIPTION
- /user/_handle_/upvotes で表示
- ナビゲーション追加
  - 「すべての回答」の後「すべての支持」
- 不支持は含まない (vote = 1のみ取得)
